### PR TITLE
Fix NuGet publish step (nupkg glob not expanded under pwsh)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,8 +132,19 @@ jobs:
         dotnet pack --configuration=release --output ../nupkgs
 
     - name: Publish to NuGet.org
+      shell: pwsh
       run: |
-        dotnet nuget push "nupkgs/*.nupkg" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+        # dotnet nuget push does not expand wildcards under pwsh (it treats
+        # "nupkgs/*.nupkg" as a literal path), so resolve the package(s) explicitly.
+        $packages = Get-ChildItem -Path nupkgs -Filter *.nupkg -File
+        if ($packages.Count -eq 0) {
+          Write-Error "No .nupkg found in nupkgs/"
+          exit 1
+        }
+        foreach ($pkg in $packages) {
+          Write-Host "Pushing $($pkg.FullName)"
+          dotnet nuget push $pkg.FullName --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+        }
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 


### PR DESCRIPTION
The v0.1.9 publish run failed at "Publish to NuGet.org" with:
`error: File does not exist (nupkgs/*.nupkg)`.

The Windows publish job runs under pwsh, where `dotnet nuget push "nupkgs/*.nupkg"`
is passed the literal glob (pwsh does not expand it and dotnet treats it as a
literal path). The Pack step DID create `nupkgs/MRuby.Library.0.1.9.nupkg` correctly.

Fix: resolve the .nupkg file(s) explicitly with `Get-ChildItem` and push each one.

After merge, the `v0.1.9` tag will be re-pointed to the new main to re-trigger the
publish workflow.
