### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a mruby-wrapper for .NET, current for Windows/Linux/MacOS and will come 
 From nuget: https://www.nuget.org/packages/MRuby.Library/
 
 ```bash
-dotnet add package MRuby.Library --version 0.1.10
+dotnet add package MRuby.Library --version 0.2.0
 ```
 
 ## How to Use

--- a/mruby-wrapper/MRuby.Library/MRuby.Library.csproj
+++ b/mruby-wrapper/MRuby.Library/MRuby.Library.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>0.1.10</Version>
+    <Version>0.2.0</Version>
     <Title>A mruby binding for .Net Core Platform</Title>
     <PackageProjectUrl>https://github.com/Little-Princess-Studio/mruby-for-dotnet</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
Release **0.2.0** — first release that includes #15 (macOS native test-host crash fix via the mruby callback trampoline / longjmp firewall).

## Changes
- `MRuby.Library.csproj` `<Version>`: `0.1.10` -> `0.2.0`
- `README.md` install command: `--version 0.1.10` -> `--version 0.2.0`

## Why minor (0.2.0), not patch
#15 is a **breaking public API change**: the trailing `out NativeMethodFunc` parameter was removed from `DefineMethod` / `DefinePrivateMethod` / `DefineClassMethod` / `DefineModuleMethod`, `RbValue.DefineSingletonMethod`, `RbState.NewProc`, and `RbState.Exception` `Protect` / `Ensure` / `Rescue` / `RescueExceptions` / `HandleException`. Callers using `out _` must drop that argument. A minor bump is the semver-correct signal while pre-1.0.

## Release mechanism
Merging this does **not** publish. Publishing is triggered by pushing the `v0.2.0` tag (`publish.yml`), which builds all three native libs, packs one cross-platform NuGet, and pushes it to nuget.org. The tag will be pushed after this merges.